### PR TITLE
"Crazy" -> "difficult"

### DIFF
--- a/solarwolf/gamehelp.py
+++ b/solarwolf/gamehelp.py
@@ -78,7 +78,7 @@ much easier to pass the level and beat the skip timer.""",
 
 "Shot Blocker":"""Shot Blocker Power Up
 This Power Up destroys all the bullets currently in space.
-It can be a life saver when things have gotten crazy.""",
+It can be a life saver when things have gotten difficult.""",
 
 "Shield":"""Shield Power Up
 This powerup enables a temporary shield on your SolarWolf


### PR DESCRIPTION
The use of the term "crazy" to refer to things with negative connotations is a form of casual sanism that unfortunately populates the English lexicon. The term "difficult" does not carry these connotations and is more precise, so this replaces the term "crazy" with "difficult" in the game's help. This page has a good explanation:

https://www.autistichoya.com/p/ableist-words-and-terms-to-avoid.html

"Crazy Eights" was left alone here because it's a reference to a card game. That game's name itself does have sanist origins, referring to mentally ill soldiers that were discharged from the military, but unfortunately the game isn't known to anyone by its original name "Eights" and the sanist origin of the game's name isn't obvious and isn't one most people today are familiar with. Perhaps changing the name of the "Crazy Eights" level to just "Eights", or possibly an alternative like "Uno", may be justified; I would make such a change if it was my own game, but since it's not and it's not a serious problem, I'm leaving that out of this pull request.