### PR TITLE
Python 3.9 compatibility

### DIFF
--- a/solarwolf/gameinit.py
+++ b/solarwolf/gameinit.py
@@ -161,7 +161,7 @@ class GameInit:
 
         now = pygame.time.get_ticks()
         #we let the screen stay up for at about 1 second
-        if not self.thread.isAlive():
+        if not self.thread.is_alive():
             if load_finished_status >= 0:
                 if now-self.starttime > 1200:
                     self.quit()


### PR DESCRIPTION
Replaced Thread.isAlive with Thread.is_alive (according to https://github.com/python/cpython/pull/15225)