### PR TITLE
Changes powerup image loading code to no longer strip alpha

### DIFF
--- a/solarwolf/objpowerup.py
+++ b/solarwolf/objpowerup.py
@@ -11,8 +11,8 @@ symbols = []
 
 def load_game_resources():
     global images, symbols
-    images = gfx.animstrip(gfx.load('powerup.png'))
-    symbols = gfx.animstrip(gfx.load('powereffects.png'))
+    images = gfx.animstrip(gfx.load_raw('powerup.png'))
+    symbols = gfx.animstrip(gfx.load_raw('powereffects.png'))
     snd.preload('select_choose')
 
 


### PR DESCRIPTION
It seems that surface.convert() didn't always strip per-pixel alpha from a surface in pygame 1. In this bit of code solarwolf was relying on that contra-documented bit of behaviour to set a colorkey for these powerups if their loaded 'parent' surface had alpha. In pygame 2 surface convert() behaves in line with the docs and strips alpha from a surface and solarwolf breaks.